### PR TITLE
Enable session config in searchSchema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/neo4j-graphql-js",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "A GraphQL to Cypher query execution layer for Neo4j. ",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -341,8 +341,13 @@ export const assertSchema = ({
   });
 };
 
-export const searchSchema = async ({ driver, schema, debug = false }) => {
-  const session = driver.session();
+export const searchSchema = async ({
+  driver,
+  schema,
+  debug = false,
+  sessionParams = {}
+}) => {
+  const session = driver.session(sessionParams);
   // drop all search indexes, given they cannot be updated via a second CALL to createNodeIndex
   const dropStatement = `
   CALL db.indexes() YIELD name, provider WHERE provider = "fulltext-1.0"


### PR DESCRIPTION
Adds a parameter `sessionParams` to `searchSchema()` so that we can target a specific database like this:

`searchSchema(driver, schema, sessionParams: { database: 'foo'})`.


Copy of https://github.com/neo4j-graphql/neo4j-graphql-js/pull/577, for internal use. 
