### PR TITLE
[ITG-968] Don't swallow errors from assertSchema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,9 +337,7 @@ export const assertSchema = ({
       )
       .finally(() => session.close());
   };
-  return executeQuery(driver).catch(error => {
-    console.error(error);
-  });
+  return executeQuery(driver);
 };
 
 export const searchSchema = async ({


### PR DESCRIPTION
Instead of `console.log`-ing the error, it should propagate so we can handle it on our side. 